### PR TITLE
Rely on Toshi API for country limitations rather than Magento

### DIFF
--- a/toshi-magento-plugin/Shipping/etc/adminhtml/system.xml
+++ b/toshi-magento-plugin/Shipping/etc/adminhtml/system.xml
@@ -32,16 +32,6 @@
                 <field id="specificerrmsg" translate="label" type="textarea" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Displayed Error Message</label>
                 </field>
-                <field id="sallowspecific" translate="label" type="select" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="0">
-                    <label>Ship to Applicable Countries</label>
-                    <frontend_class>shipping-applicable-country</frontend_class>
-                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
-                </field>
-                <field id="specificcountry" translate="label" type="multiselect" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="0">
-                    <label>Ship to Specific Countries</label>
-                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                    <can_be_empty>1</can_be_empty>
-                </field>
                 <field id="showmethod" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Method if Not Applicable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/toshi-magento-plugin/Shipping/etc/config.xml
+++ b/toshi-magento-plugin/Shipping/etc/config.xml
@@ -11,8 +11,6 @@
                 <title>Try Before you Buy with TOSHI</title>
                 <specificerrmsg>This shipping method is not available. To use this shipping method, please contact us.</specificerrmsg>
                 <sort_order>-1</sort_order>
-                <sallowspecific>1</sallowspecific>
-                <specificcountry>GB</specificcountry>
                 <toshi_min_basket_amount>350</toshi_min_basket_amount>
                 <size_attribute>size</size_attribute>
                 <color_attribute>color</color_attribute>


### PR DESCRIPTION
I've removed 
```                
<sallowspecific>1</sallowspecific>
<specificcountry>GB</specificcountry>
```
As this was causing Magento to block Toshi based on specific countries. The actual country selector was also hidden on the config. 
I've removed that too since it this could then use Toshi as the main point of truth when trying to check if a country is allowed rather than Magento. 

